### PR TITLE
Reformat log messages, switch from warn to err

### DIFF
--- a/src/mod/simargs.zig
+++ b/src/mod/simargs.zig
@@ -438,7 +438,7 @@ fn OptionParser(
                             // short option
                             const short_name = arg[1..];
                             if (short_name.len != 1) {
-                                std.log.warn("No such short option, name:{s}", .{arg});
+                                std.log.err("No such short option '{s}'", .{arg});
                                 return error.NoOption;
                             }
                             for (&self.opt_fields) |*opt| {
@@ -452,7 +452,7 @@ fn OptionParser(
                         }
 
                         var opt = current_opt orelse {
-                            std.log.warn("Unknown option, name:{s}", .{arg});
+                            std.log.err("Unknown option '{s}'", .{arg});
                             return error.NoOption;
                         };
 
@@ -502,7 +502,7 @@ fn OptionParser(
             inline for (self.opt_fields) |opt| {
                 if (opt.opt_type.is_required()) {
                     if (!opt.is_set) {
-                        std.log.warn("Missing required option, name:{s}", .{opt.long_name});
+                        std.log.err("Missing required option '{s}'", .{opt.long_name});
                         return error.MissingRequiredOption;
                     }
                 }


### PR DESCRIPTION
These logs are followed by the return of an error value -- most likely,
a user of this library will follow this call by exiting the program. It
is better that an end user sees these messages marked as "error" rather
than "warning".

The messages themselves have been slightly reformatted to make them
easier to read for the end user.
