### PR TITLE
mitigate error: ProcessFdQuotaExceeded for loc

### DIFF
--- a/src/bin/loc.zig
+++ b/src/bin/loc.zig
@@ -212,7 +212,7 @@ pub fn main() !void {
         opt.positional_args[0];
 
     var loc_map = LocMap{};
-    const dir = fs.cwd().openDir(file_or_dir, .{ .iterate = true }) catch |err| switch (err) {
+    var dir = fs.cwd().openDir(file_or_dir, .{ .iterate = true }) catch |err| switch (err) {
         error.NotDir => {
             try populateLoc(allocator, &loc_map, fs.cwd(), file_or_dir);
             return printLocMap(
@@ -225,6 +225,7 @@ pub fn main() !void {
         },
         else => return err,
     };
+    defer dir.close();
     try walk(allocator, &loc_map, dir);
     try printLocMap(
         allocator,
@@ -289,7 +290,8 @@ fn walk(allocator: std.mem.Allocator, loc_map: *LocMap, dir: fs.Dir) anyerror!vo
                     }
                 }
                 if (!should_ignore) {
-                    const sub_dir = try dir.openDir(e.name, .{ .iterate = true });
+                    var sub_dir = try dir.openDir(e.name, .{ .iterate = true });
+                    defer sub_dir.close();
                     try walk(allocator, loc_map, sub_dir);
                 }
             },


### PR DESCRIPTION
Close opened directories as soon as possible to mitigate error: ProcessFdQuotaExceeded for loc.

Tested on macOS 12.7.6 x86_64.
```shell
% ulimit -n
256
```
Prepare some source code, e.g.
```shell
% git clone https://github.com/asterinas/asterinas.git
..., done.
% cd asterinas/
```
Testing with tokei:
```shell
% tokei
===============================================================================
 Language            Files        Lines         Code     Comments       Blanks
===============================================================================
 GNU Style Assembly     19         1542         1135          215          192
 C                      48         5560         4150          358         1052
 C Header                1          164           73           77           14
 JSON                  119         1334         1334            0            0
 Makefile               30          845          629           71          145
 Python                  2          136          110            3           23
 Shell                  91         2171         1270          377          524
 SVG                     4         1532         1530            2            0
 TOML                   70         1167          882          105          180
-------------------------------------------------------------------------------
 Markdown               52         2703            0         2056          647
 |- BASH                22          119          113            5            1
 |- JSON                 1           30           30            0            0
 |- Markdown             1            2            0            2            0
 |- Rust                 6           63           52            2            9
 |- Shell                2           33           18            9            6
 |- TOML                 6           80           69            6            5
 |- YAML                 1            4            4            0            0
 (Total)                           3034          286         2080          668
-------------------------------------------------------------------------------
 Rust                  786        98010        79517         4387        14106
 |- Markdown           515        12129          291         9778         2060
 (Total)                         110139        79808        14165        16166
===============================================================================
 Total                1222       115164        90630         7651        16883
===============================================================================
```
Testing with loc before patch:
```shell
% loc
error: ProcessFdQuotaExceeded
```
Testing with loc after patch:
```shell
% loc
┌───────────┬───────┬─────────┬────────┬──────────┬────────┬──────────┐
│Language   │File   │Line     │Code    │Comment   │Blank   │Size      │
├───────────┼───────┼─────────┼────────┼──────────┼────────┼──────────┤
│Rust       │786    │110203   │79636   │16434     │14133   │3.33M     │
│C          │48     │5560     │4150    │358       │1052    │130.75K   │
│Markdown   │60     │3263     │2412    │98        │753     │120.30K   │
│Bash       │91     │2171     │1270    │377       │524     │56.02K    │
│JSON       │121    │1371     │1371    │0         │0       │33.26K    │
│TOML       │72     │1206     │914     │109       │183     │32.66K    │
│Makefile   │29     │812      │603     │70        │139     │20.75K    │
│YAML       │11     │727      │608     │47        │72      │24.15K    │
│CHeader    │1      │164      │73      │77        │14      │6.43K     │
│Python     │2      │136      │110     │3         │23      │4.61K     │
├───────────┼───────┼─────────┼────────┼──────────┼────────┼──────────┤
│Total      │1221   │125613   │91147   │17573     │16893   │3.75M     │
└───────────┴───────┴─────────┴────────┴──────────┴────────┴──────────┘

```