### PR TITLE
Fix integer overflow error for blanks

### DIFF
--- a/src/mod/simargs.zig
+++ b/src/mod/simargs.zig
@@ -258,7 +258,11 @@ const MessageHelper = struct {
                 var lst = std.ArrayList([]const u8).init(aa);
                 try lst.append("[COMMANDS]\n\n COMMANDS:");
                 for (cmds) |cmd| {
-                    try lst.append(try std.fmt.allocPrint(aa, "  {s:<10} {s}", .{ cmd.name, cmd.message }));
+                    if (cmd.name.len <= 10) {
+                        try lst.append(try std.fmt.allocPrint(aa, "  {s:<10} {s}", .{ cmd.name, cmd.message }));
+                    } else {
+                        try lst.append(try std.fmt.allocPrint(aa, "  {s}\n  {s:<10} {s}", .{ cmd.name, "", cmd.message }));
+                    }
                 }
                 break :blk try std.mem.join(aa, "\n", lst.items);
             } else if (self.arg_prompt) |p|
@@ -292,9 +296,13 @@ const MessageHelper = struct {
 
             var blanks: usize = msg_offset;
             for (curr_opt.items) |v| {
-                blanks -= v.len;
+                blanks = if (blanks > v.len) blanks - v.len else 0;
             }
-            while (blanks > 0) {
+
+            if (blanks == 0) {
+                try curr_opt.append("\n");
+                try curr_opt.append(" " ** 35);
+            } else while (blanks > 0) {
                 try curr_opt.append(" ");
                 blanks -= 1;
             }


### PR DESCRIPTION
**PR Summary**
- Fix blanks var overflow for long options
- Make message or description continue on a new line when command name or option name is long

**Description**
var blanks overflow when the length of any of the options is longer than the value of blanks. In cases where the command or the option is long, the description message is made to continue on a new line. This is the implementation I found when I ran `swift -h` or `rustc -h`.

<img width="1357" height="430" alt="Screenshot 2025-09-21 at 02 42 59" src="https://github.com/user-attachments/assets/25578421-1cde-4148-bbd9-f163fc3c0876" />
<img width="722" height="340" alt="Screenshot 2025-09-21 at 02 42 20" src="https://github.com/user-attachments/assets/cabcf678-c704-4eb4-a88a-e94e8733b8d0" />


