### PR TITLE
Fixed Windows UTF-8 console output for `tree` & `table` + tests

### DIFF
--- a/docs/content/packages/term.org
+++ b/docs/content/packages/term.org
@@ -15,6 +15,7 @@ capability checks without pulling table rendering into your own code.
 - =Style.Color= defines the standard ANSI foreground/background colors, including bright variants
 - =Style= combines bold, italic, foreground color, and background color into one reusable value
 - =isTty(file)= reports whether a file is attached to an interactive terminal
+- =enableUtf8ConsoleOutput(file)= temporarily switches a Windows console to UTF-8 output for UTF-8 text
 - =terminalWidth(file)= returns the terminal width when it can be detected, otherwise =null=
 - =stdoutWidth()= is a convenience wrapper for the common stdout case
 
@@ -97,6 +98,27 @@ Use =isTty()= when color or formatting should only be enabled for interactive te
 if (term.isTty(std.fs.File.stdout())) {
     try term.Style.Color.cyan.writeString(&writer.interface, "interactive");
 }
+#+end_src
+
+** =enableUtf8ConsoleOutput(file)=
+
+Use =enableUtf8ConsoleOutput()= when a Windows CLI will emit UTF-8 line-drawing or other non-ASCII
+text directly to an interactive console. The helper is best-effort:
+
+- non-Windows platforms return a no-op guard
+- redirected or piped output stays unchanged
+- the original Windows console output code page is restored in =defer=
+
+#+begin_src zig
+const stdout = std.fs.File.stdout();
+const utf8_console = term.enableUtf8ConsoleOutput(stdout);
+defer utf8_console.deinit();
+
+var buffer: [1024]u8 = undefined;
+var writer = stdout.writer(&buffer);
+
+try writer.interface.writeAll("├── example\n");
+try writer.interface.flush();
 #+end_src
 
 ** =terminalWidth(file)=

--- a/src/bin/loc.zig
+++ b/src/bin/loc.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const zigcli = @import("zigcli");
 const pt = zigcli.pretty_table;
+const term = zigcli.term;
 const Table = pt.Table;
 const Cell = pt.Cell;
 const Separator = pt.Separator;
@@ -292,6 +293,12 @@ fn printLocMap(
         .padding = padding,
     };
     const stdout = std.fs.File.stdout();
+    const utf8_console = if (mode != .ascii)
+        term.enableUtf8ConsoleOutput(stdout)
+    else
+        term.Utf8ConsoleOutput.noop;
+    defer utf8_console.deinit();
+
     var buf: [1024]u8 = undefined;
     var writer = stdout.writer(&buf);
     try writer.interface.print("{f}\n", .{table});
@@ -387,17 +394,7 @@ fn populateLoc(allocator: std.mem.Allocator, loc_map: *LocMap, dir: fs.Dir, base
         .windows => {
             var buf: [1024]u8 = undefined;
             var rdr = file.reader(&buf);
-            while (true) {
-                const line = rdr.interface.takeDelimiterExclusive('\n') catch |e| {
-                    switch (e) {
-                        error.EndOfStream => return,
-                        else => {
-                            std.log.err("Error when seek line delimiter, name:{s}, err:{any}", .{ basename, e });
-                            return e;
-                        },
-                    }
-                };
-
+            while (try rdr.interface.takeDelimiter('\n')) |line| {
                 state = updateLineType(state, line, lang, loc_entry);
             }
         },

--- a/src/bin/pretty-csv.zig
+++ b/src/bin/pretty-csv.zig
@@ -5,6 +5,7 @@ const zigcli = @import("zigcli");
 const csv = zigcli.csv;
 const structargs = zigcli.structargs;
 const pt = zigcli.pretty_table;
+const term = zigcli.term;
 const util = @import("util.zig");
 const mem = std.mem;
 
@@ -108,6 +109,12 @@ pub fn main() !void {
         document.num_cols;
 
     const stdout = std.fs.File.stdout();
+    const utf8_console = if (opt.options.style != .ascii)
+        term.enableUtf8ConsoleOutput(stdout)
+    else
+        term.Utf8ConsoleOutput.noop;
+    defer utf8_console.deinit();
+
     var output_buf: [8192]u8 = undefined;
     var stdout_writer = stdout.writer(&output_buf);
     const writer = &stdout_writer.interface;

--- a/src/bin/tree.zig
+++ b/src/bin/tree.zig
@@ -8,6 +8,7 @@
 const std = @import("std");
 const zigcli = @import("zigcli");
 const structargs = zigcli.structargs;
+const term = zigcli.term;
 const util = @import("util.zig");
 const gitignore = zigcli.gitignore;
 const StringUtil = util.StringUtil;
@@ -41,6 +42,13 @@ const PREFIX_ARR = [_][4][]const u8{ // mode -> position
 
 fn getPrefix(mode: Mode, pos: Position) []const u8 {
     return PREFIX_ARR[@intFromEnum(mode)][@intFromEnum(pos)];
+}
+
+fn modeNeedsUtf8Console(mode: Mode) bool {
+    return switch (mode) {
+        .ascii => false,
+        .box, .dos => true,
+    };
 }
 
 pub const WalkOptions = struct {
@@ -96,6 +104,12 @@ pub fn main() anyerror!void {
         opt.positional_arguments[0];
 
     const stdout = std.fs.File.stdout();
+    const utf8_console = if (modeNeedsUtf8Console(opt.options.mode))
+        term.enableUtf8ConsoleOutput(stdout)
+    else
+        term.Utf8ConsoleOutput.noop;
+    defer utf8_console.deinit();
+
     var buf: [1024]u8 = undefined;
     var writer = stdout.writer(&buf);
 
@@ -145,6 +159,12 @@ test "testing string lessThan" {
     inline for (testcases) |case| {
         try testing.expectEqual(case.@"2", stringLessThan(case.@"0", case.@"1"));
     }
+}
+
+test "tree mode utf8 console gating" {
+    try testing.expect(!modeNeedsUtf8Console(.ascii));
+    try testing.expect(modeNeedsUtf8Console(.box));
+    try testing.expect(modeNeedsUtf8Console(.dos));
 }
 
 const WalkResult = struct {

--- a/src/term.zig
+++ b/src/term.zig
@@ -2,6 +2,9 @@
 
 const builtin = @import("builtin");
 const std = @import("std");
+const windows = std.os.windows;
+
+const utf8_code_page: windows.UINT = 65001;
 
 /// ANSI text styling that can be composed from weight, emphasis, and colors.
 pub const Style = struct {
@@ -133,9 +136,98 @@ pub const Style = struct {
     }
 };
 
+/// Best-effort guard for temporarily switching a Windows console to UTF-8 output.
+pub const Utf8ConsoleOutput = struct {
+    original_code_page: ?windows.UINT = null,
+
+    pub const noop: Utf8ConsoleOutput = .{};
+
+    /// Restores the original console output code page when this process changed it.
+    pub fn deinit(self: Utf8ConsoleOutput) void {
+        if (builtin.os.tag != .windows) {
+            return;
+        }
+
+        const original_code_page = self.original_code_page orelse {
+            return;
+        };
+
+        _ = windows.kernel32.SetConsoleOutputCP(original_code_page);
+    }
+};
+
+const Utf8ConsoleDecision = struct {
+    original_code_page: ?windows.UINT = null,
+
+    fn init(
+        is_windows: bool,
+        is_tty: bool,
+        current_code_page: ?windows.UINT,
+    ) Utf8ConsoleDecision {
+        if (!is_windows) {
+            return .{};
+        }
+        if (!is_tty) {
+            return .{};
+        }
+
+        const original_code_page = current_code_page orelse {
+            return .{};
+        };
+        if (original_code_page == utf8_code_page) {
+            return .{};
+        }
+
+        return .{ .original_code_page = original_code_page };
+    }
+
+    fn shouldSet(self: Utf8ConsoleDecision) bool {
+        return self.original_code_page != null;
+    }
+
+    fn toGuard(
+        self: Utf8ConsoleDecision,
+        set_succeeded: bool,
+    ) Utf8ConsoleOutput {
+        if (!set_succeeded) {
+            return .noop;
+        }
+
+        return .{ .original_code_page = self.original_code_page };
+    }
+};
+
 /// Reports whether `file` is attached to an interactive terminal.
 pub fn isTty(file: std.fs.File) bool {
     return file.isTty();
+}
+
+fn currentConsoleOutputCodePage() ?windows.UINT {
+    if (builtin.os.tag != .windows) {
+        return null;
+    }
+
+    const code_page = windows.kernel32.GetConsoleOutputCP();
+    if (code_page == 0) {
+        return null;
+    }
+
+    return code_page;
+}
+
+/// Switches an attached Windows console to UTF-8 output and returns a restoration guard.
+pub fn enableUtf8ConsoleOutput(file: std.fs.File) Utf8ConsoleOutput {
+    const decision = Utf8ConsoleDecision.init(
+        builtin.os.tag == .windows,
+        file.isTty(),
+        currentConsoleOutputCodePage(),
+    );
+    if (!decision.shouldSet()) {
+        return .noop;
+    }
+
+    const set_succeeded = windows.kernel32.SetConsoleOutputCP(utf8_code_page) != 0;
+    return decision.toGuard(set_succeeded);
 }
 
 /// Returns the detected terminal width for `file`, or `null` when unavailable.
@@ -204,5 +296,49 @@ test "term style write string" {
     try std.testing.expectEqualStrings(
         "\x1b[1m\x1b[3m\x1b[32m\x1b[40mok\x1b[0m",
         allocating.written(),
+    );
+}
+
+test "utf8 console decision skips non-windows" {
+    const decision = Utf8ConsoleDecision.init(false, true, 437);
+
+    try std.testing.expect(!decision.shouldSet());
+}
+
+test "utf8 console decision skips non-tty windows output" {
+    const decision = Utf8ConsoleDecision.init(true, false, 437);
+
+    try std.testing.expect(!decision.shouldSet());
+}
+
+test "utf8 console decision skips when already utf8" {
+    const decision = Utf8ConsoleDecision.init(true, true, utf8_code_page);
+
+    try std.testing.expect(!decision.shouldSet());
+}
+
+test "utf8 console decision requests windows tty change" {
+    const decision = Utf8ConsoleDecision.init(true, true, 437);
+
+    try std.testing.expect(decision.shouldSet());
+    try std.testing.expectEqual(
+        @as(?windows.UINT, 437),
+        decision.original_code_page,
+    );
+}
+
+test "utf8 console guard restores only after successful change" {
+    const decision = Utf8ConsoleDecision.init(true, true, 437);
+
+    const failed_guard = decision.toGuard(false);
+    try std.testing.expectEqual(
+        @as(?windows.UINT, null),
+        failed_guard.original_code_page,
+    );
+
+    const applied_guard = decision.toGuard(true);
+    try std.testing.expectEqual(
+        @as(?windows.UINT, 437),
+        applied_guard.original_code_page,
     );
 }

--- a/src/term.zig
+++ b/src/term.zig
@@ -152,6 +152,8 @@ pub const Utf8ConsoleOutput = struct {
             return;
         };
 
+        // Restoring the original code page is best-effort. If this fails, the
+        // console may remain in UTF-8 mode after the process exits.
         _ = windows.kernel32.SetConsoleOutputCP(original_code_page);
     }
 };
@@ -217,6 +219,10 @@ fn currentConsoleOutputCodePage() ?windows.UINT {
 
 /// Switches an attached Windows console to UTF-8 output and returns a restoration guard.
 pub fn enableUtf8ConsoleOutput(file: std.fs.File) Utf8ConsoleOutput {
+    if (builtin.os.tag != .windows) {
+        return .noop;
+    }
+
     const decision = Utf8ConsoleDecision.init(
         builtin.os.tag == .windows,
         file.isTty(),


### PR DESCRIPTION
## Summary

This PR fixes broken console output (a.k.a. mojibake) on Windows for the UTF-8 box-drawing modes of `tree`, `loc`, and `pretty-csv`.

This adds a shared `zigcli.term` helper that temporarily switches an attached Windows console's output code page to UTF-8 for commands that emit non-ASCII border/tree glyphs by default, while leaving redirected output unchanged.

**Non-Windows targets remain unchanged.**

## Reason for PR

When running the Windows executables under WSL interop / Windows Terminal, UTF-8 box-drawing characters were being reinterpreted through the console's active code page and showed up as mojibake.

Example:

- Expected: `├──`
- Actual: `Γö£ΓöÇΓöÇ`

Redirected output was already correct, which pointed to console-layer translation rather than incorrect UTF-8 generation.

## Changes

- Added `term.enableUtf8ConsoleOutput(file)` and `term.Utf8ConsoleOutput` in `src/term.zig`
- Restores the original Windows console output code page on exit when after our process changes it
- Wired the helper into:
  - `tree` for `.box` and `.dos` modes
  - `loc` for non-ASCII separator modes
  - `pretty-csv` for non-ASCII separator modes
- Added `term` docs for the new helper
- Updated the Windows line-reading loop in `loc` to use `takeDelimiter('\n')` instead of `takeDelimiterExclusive('\n')`


## Additional note on `loc`

While verifying this change, `zig build test-loc` was hanging on Windows in the `LOC Zig/Python/Ruby` test.

Note: this issue is unrelated to the stdout test issue (https://github.com/ziglang/zig/issues/18111) and instead comes from the Zig 0.15.2 `std.Io.Reader.takeDelimiterExclusive('\n')` behavior on the Windows code path. Switching `loc` to `takeDelimiter('\n')` fixes the hang and matches the recommended usage for this Zig version.

## Verification

Automated tests passed:

- `zig build test-tree`
- `zig build test-pretty-csv`
- `zig build test-loc`
- `zig build test`

Manual passes in WSL / Windows Terminal:

- `tree.exe` renders UTF-8 tree glyphs correctly
- `loc.exe` renders UTF-8 box borders correctly
- `pretty-csv.exe` renders UTF-8 box borders correctly
- ASCII modes still work as expected
- redirected output still preserves valid UTF-8 bytes

## Scope / behavior

- Windows-only behavior change
- No CLI flags changed
- No change for redirected or piped output
- No change for Linux/macOS behavior
- `pretty-table` itself remains side-effect free; console setup stays in CLI entrypoints