### PR TITLE
fix(build): enable zigfetch on Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,17 +56,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        targets:
-          - x86_64-windows
-          - x86_64-linux
-          - x86_64-macos
-          - aarch64-macos
-          - x86_64-freebsd
-          - aarch64-freebsd
+        include:
+          - os: windows-latest
+            target: x86_64-windows
+          - os: ubuntu-latest
+            target: x86_64-linux
+          - os: ubuntu-latest
+            target: x86_64-macos
+          - os: ubuntu-latest
+            target: aarch64-macos
+          - os: ubuntu-latest
+            target: x86_64-freebsd
+          - os: ubuntu-latest
+            target: aarch64-freebsd
     steps:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
       - name: Build
         run: |
-          zig build -Dtarget=${{ matrix.targets }}
+          zig build -Dtarget=${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,15 +29,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        targets:
-          - "aarch64-linux"
-          - "x86_64-linux"
-          - "x86_64-macos"
-          - "x86_64-windows"
-          - "aarch64-windows"
-          - "x86_64-freebsd"
-          - "aarch64-freebsd"
+        include:
+          - os: ubuntu-latest
+            target: aarch64-linux
+          - os: ubuntu-latest
+            target: x86_64-linux
+          - os: ubuntu-latest
+            target: x86_64-macos
+          - os: ubuntu-latest
+            target: aarch64-windows
+          - os: ubuntu-latest
+            target: x86_64-freebsd
+          - os: ubuntu-latest
+            target: aarch64-freebsd
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -45,18 +49,20 @@ jobs:
       - uses: mlugg/setup-zig@v2
       - name: Set env(release)
         if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
         run: |
           echo "RELEASE_VERSION=${{  github.ref_name }}" >> $GITHUB_ENV
           echo "OUT_DIR=/tmp/zigcli" >> $GITHUB_ENV
       - name: Set env(dev)
         if: "!startsWith(github.ref, 'refs/tags/')"
+        shell: bash
         run: |
           echo "RELEASE_VERSION=nightly" >> $GITHUB_ENV
           echo "OUT_DIR=/tmp/zigcli" >> $GITHUB_ENV
-      - name: Build(Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Build
+        shell: bash
         run: |
-          export TARGET="${{ matrix.targets }}"
+          export TARGET="${{ matrix.target }}"
           bash .github/release-single.sh
       - name: Release
         uses: softprops/action-gh-release@v2
@@ -67,7 +73,45 @@ jobs:
         if: "!startsWith(github.ref, 'refs/tags/')"
         uses: actions/upload-artifact@v4
         with:
-          name: zigcli-${{ matrix.os }}-${{ matrix.targets }}
+          name: zigcli-${{ matrix.os }}-${{ matrix.target }}
+          path: ${{ env.OUT_DIR }}
+
+  upload-assets-win:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: mlugg/setup-zig@v2
+      - name: Set env(release)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          "RELEASE_VERSION=${{ github.ref_name }}" >> $env:GITHUB_ENV
+          "OUT_DIR=$env:TEMP\zigcli" >> $env:GITHUB_ENV
+      - name: Set env(dev)
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        run: |
+          "RELEASE_VERSION=nightly" >> $env:GITHUB_ENV
+          "OUT_DIR=$env:TEMP\zigcli" >> $env:GITHUB_ENV
+      - name: Build(Windows)
+        run: |
+          $git_commit = git rev-parse --short HEAD
+          $build_date = Get-Date -Format "yyyy-MM-ddTHH:mm:ssK"
+          New-Item -ItemType Directory -Force -Path $env:OUT_DIR
+          zig build -Doptimize=ReleaseSafe `
+          -Dgit_commit=$git_commit -Dbuild_date=$build_date -Dversion=$env:RELEASE_VERSION
+          Remove-Item zig-out/bin/*demo
+          Copy-Item LICENSE, README.org zig-out
+          Compress-Archive -Path zig-out/* -DestinationPath "$env:OUT_DIR/zigcli-$env:RELEASE_VERSION-x86_64-windows.zip"
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ${{ env.OUT_DIR }}/*
+      - name: Upload
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        uses: actions/upload-artifact@v4
+        with:
+          name: zigcli-windows-latest
           path: ${{ env.OUT_DIR }}
 
   upload-assets-mac:

--- a/build.zig
+++ b/build.zig
@@ -263,14 +263,6 @@ fn sourceSupported(
         }
     }
 
-    if (std.mem.eql(u8, source_name, "zigfetch")) {
-        // .zig-cache/o/3390549d3c902e4c2db17c04c316202a/c.zig:2199:15: error: unused local constant
-        // const extern_local_wcscat_s = struct {
-        if (target_os == .windows) {
-            return false;
-        }
-    }
-
     if (std.mem.eql(u8, source_name, "timeout")) {
         // Windows still lacks the required Sigaction definition here.
         if (target_os == .windows) {


### PR DESCRIPTION
Remove the exclusion for zigfetch on Windows targets. The unused local constant error in the generated C code has been resolved, making this workaround no longer necessary.